### PR TITLE
Fix php warning when q['author'] is an array

### DIFF
--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -614,7 +614,12 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 
 		// Author/user stuff
 		if ( ! empty( $q['author'] ) && $q['author'] != '0' ) {
-			$q['author'] = addslashes_gpc( '' . urldecode( $q['author'] ) );
+			if ( is_array( $q['author'] ) ){
+				$q['author'] = array_map( 'urldecode', $q['author'] );
+				$q['author'] = array_map( 'addslashes_gpc', $q['author'] );
+			} else {
+				$q['author'] = addslashes_gpc( '' . urldecode( $q['author'] ) );
+			}
 			$authors = array_unique( array_map( 'intval', preg_split( '/[,\s]+/', $q['author'] ) ) );
 			foreach ( $authors as $author ) {
 				$key = $author > 0 ? 'author__in' : 'author__not_in';


### PR DESCRIPTION
If q['author'] is passed an array urldecode will throw "PHP Warning: urldecode() expects parameter 1 to be string, array given"