### PR TITLE
Fix for search for one meta and sort with another

### DIFF
--- a/class-es-wp-meta-query.php
+++ b/class-es-wp-meta-query.php
@@ -46,11 +46,15 @@ class ES_WP_Meta_Query extends WP_Meta_Query {
 				}
 				unset( $this->queries[ $k ] );
 			} else {
-				$queries[ $k ] = $q;
+				$queries = array_merge( $queries, $q );
 			}
 		}
 
 		foreach ( $queries as $k => $q ) {
+			if ( 'relation' === $k ) {
+				continue;
+			}
+			
 			$meta_key = isset( $q['key'] ) ? trim( $q['key'] ) : '*';
 
 			if ( array_key_exists( 'value', $q ) && is_null( $q['value'] ) )


### PR DESCRIPTION
Xiao ( @xyu ) from our Elasticsearch team found a problem when working on a bug for a client:
It appears that es-wp-query is unable to deal with the nested parsed meta query array from WP_Query when trying to search on one meta value and then sorting on another.
I'm not 100% sure I understand how this fixes it but I wanted to send this upstream for feedback before we deploy it.