### PR TITLE
explicitly specify the index name

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -7,6 +7,9 @@
 class ES_WP_Query extends ES_WP_Query_Wrapper {
 	protected function query_es( $es_args ) {
 		if ( function_exists( 'es_api_search_index' ) ) {
+			$es_args['name'] = es_api_get_index_name_by_blog_id( $es_args['blog_id'] );
+			if ( is_wp_error( $es_args['name'] ) )
+				return $es_args['name'];
 			return es_api_search_index( $es_args, 'es-wp-query' );
 		}
 	}


### PR DESCRIPTION
To ensure exact index selection, moving away from using blog_id.
in cases of VIP indices we can lookup the index name based on the siteurl()
props @gibrown