### PR TITLE
Use author ID instead of nicename for author archive queries

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -90,6 +90,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 function vip_es_field_map( $es_map ) {
 	return wp_parse_args( array(
 		'post_author'                   => 'author_id',
+		'post_author.user_login'        => 'author_login',
 		'post_date'                     => 'date',
 		'post_date.year'                => 'date_token.year',
 		'post_date.month'               => 'date_token.month',

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -6,9 +6,25 @@
 
 class ES_WP_Query extends ES_WP_Query_Wrapper {
 	protected function query_es( $es_args ) {
-		if ( function_exists( 'es_api_search_index' ) ) {
-			return es_api_search_index( $es_args, 'es-wp-query' );
+		if ( ! function_exists( 'es_api_search_index' ) ) {
+			return new WP_Error( 'vip-es-api-missing', 'Missing es_api_search_index method' );
 		}
+
+		/**
+		 * VIP ES index doesn't have the user_nicename so we fetch the user ID.
+		 * @see https://developer.wordpress.com/docs/elasticsearch/post-doc-schema/
+		 */
+		if ( isset( $es_args['post_author.user_nicename'] ) ) {
+			// slug is mapped to user_nicename by get_data_by() in WP_User
+			$user_by_slug = get_user_by( 'slug', $es_args['post_author.user_nicename'] );
+
+			if ( isset( $user_by_slug->ID ) ) {
+				$es_args['author_id'] = $user_by_slug->ID;
+				unset( $es_args['post_author.user_nicename'] );
+			}
+		}
+
+		return es_api_search_index( $es_args, 'es-wp-query' );
 	}
 
 	protected function set_posts( $q, $es_response ) {

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -77,6 +77,7 @@ function vip_es_field_map( $es_map ) {
 	return wp_parse_args( array(
 		'post_author'                   => 'author_id',
 		'post_author.user_login'        => 'author_login',
+		'post_author.user_nicename'     => 'author_login',
 		'post_date'                     => 'date',
 		'post_date.year'                => 'date_token.year',
 		'post_date.month'               => 'date_token.month',
@@ -155,25 +156,3 @@ function vip_es_meta_value_tolower( $meta_value, $meta_key, $meta_compare, $meta
 	return $meta_value;
 }
 add_filter( 'es_meta_query_meta_value', 'vip_es_meta_value_tolower', 10, 4 );
-
-/**
- * VIP ES index doesn't have the user_nicename so we lookup the user ID.
- * @see https://developer.wordpress.com/docs/elasticsearch/post-doc-schema/
- */
-function vip_es_query_filter( $filter ) {
-	foreach ( $filter as $filter_no => $filter_rule ) {
-		if ( isset( $filter_rule['term']['post_author.user_nicename'] ) ) {
-			// slug is mapped to user_nicename by get_data_by() in WP_User
-			$user_by_slug = get_user_by( 'slug', $filter_rule['term']['post_author.user_nicename'] );
-
-			if ( isset( $user_by_slug->ID ) ) {
-				$filter[ $filter_no ]['term']['author_id'] = intval( $user_by_slug->ID );
-				unset( $filter[ $filter_no ]['term']['post_author.user_nicename'] );
-			} else {
-				unset( $filter[ $filter_no ] );
-			}
-		}
-	}
-	return $filter;
-}
-add_filter( 'es_query_filter', 'vip_es_query_filter' );

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -10,20 +10,6 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 			return new WP_Error( 'vip-es-api-missing', 'Missing es_api_search_index method' );
 		}
 
-		/**
-		 * VIP ES index doesn't have the user_nicename so we fetch the user ID.
-		 * @see https://developer.wordpress.com/docs/elasticsearch/post-doc-schema/
-		 */
-		if ( isset( $es_args['post_author.user_nicename'] ) ) {
-			// slug is mapped to user_nicename by get_data_by() in WP_User
-			$user_by_slug = get_user_by( 'slug', $es_args['post_author.user_nicename'] );
-
-			if ( isset( $user_by_slug->ID ) ) {
-				$es_args['author_id'] = $user_by_slug->ID;
-				unset( $es_args['post_author.user_nicename'] );
-			}
-		}
-
 		return es_api_search_index( $es_args, 'es-wp-query' );
 	}
 

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -647,7 +647,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 			$q['author_name'] = sanitize_title_for_query( $q['author_name'] );
 			$author_by_slug = get_user_by( 'slug', $q['author_name'] );
 			if ( isset( $author_by_slug->ID ) ) {
-				$filter[] = $this->dsl_terms( $this->es_map( 'post_author' ), $author_by_slug->ID );
+				$filter[] = $this->dsl_terms( $this->es_map( 'post_author' ), absint( $author_by_slug->ID ) );
 			}
 		}
 

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -645,10 +645,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 				}
 			}
 			$q['author_name'] = sanitize_title_for_query( $q['author_name'] );
-			$author_by_slug = get_user_by( 'slug', $q['author_name'] );
-			if ( isset( $author_by_slug->ID ) ) {
-				$filter[] = $this->dsl_terms( $this->es_map( 'post_author' ), absint( $author_by_slug->ID ) );
-			}
+			$filter[] = $this->dsl_terms( $this->es_map( 'post_author.user_nicename' ), $q['author_name'] );
 		}
 
 		// MIME-Type stuff for attachment browsing

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -645,7 +645,10 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 				}
 			}
 			$q['author_name'] = sanitize_title_for_query( $q['author_name'] );
-			$filter[] = $this->dsl_terms( $this->es_map( 'post_author.user_nicename' ), $q['author_name'] );
+			$author_by_slug = get_user_by( 'slug', $q['author_name'] );
+			if ( isset( $author_by_slug->ID ) ) {
+				$filter[] = $this->dsl_terms( $this->es_map( 'post_author' ), $author_by_slug->ID );
+			}
 		}
 
 		// MIME-Type stuff for attachment browsing


### PR DESCRIPTION
_Ready for code review._

WordPress core [maps `author_name` to the user ID](https://github.com/WordPress/WordPress/blob/97fd5ae77c6f226577c1bf8ad0d5140030d32b07/wp-includes/class-wp-query.php#L2121-L2123) for the author archive queries.

We are having an issue on VIP (ZD ticket 60751) where author archives `http://example.com/author/username` which rewrite to `http://example.com/?author_name=username` are returning a 404. It appears that VIP doesn't have a field for `post_author.user_nicename` in the ES index.

Maybe also related to #43.