### PR TITLE
Update adapter to work with author page queries

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -74,6 +74,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 function vip_es_field_map( $es_map ) {
 	return wp_parse_args( array(
 		'post_author'                   => 'author_id',
+		'post_author.user_login'        => 'author_login',
 		'post_author.user_nicename'     => 'author_login',
 		'post_date'                     => 'date',
 		'post_date.year'                => 'date_token.year',

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -74,6 +74,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 function vip_es_field_map( $es_map ) {
 	return wp_parse_args( array(
 		'post_author'                   => 'author_id',
+		'post_author.user_nicename'     => 'author_login',
 		'post_date'                     => 'date',
 		'post_date.year'                => 'date_token.year',
 		'post_date.month'               => 'date_token.month',

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -74,7 +74,6 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 function vip_es_field_map( $es_map ) {
 	return wp_parse_args( array(
 		'post_author'                   => 'author_id',
-		'post_author.user_login'        => 'author_login',
 		'post_author.user_nicename'     => 'author_login',
 		'post_date'                     => 'date',
 		'post_date.year'                => 'date_token.year',


### PR DESCRIPTION
The WordPress.com [Elasticsearch Post Document Schema](https://developer.wordpress.com/docs/elasticsearch/post-doc-schema/#es-mapping-post-author) doesn't have `post_author.user_nicename`, so this PR maps it to `author_login`.

This should work in all situations on WordPress.com because we prevent email addresses etc. being used as usernames during signup.

Fixes #46