### PR TITLE
Prevent infinite loops! 

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -22,7 +22,7 @@ add_filter( 'query_vars', 'es_wp_query_arg' );
  */
 function es_wp_query_shoehorn( &$query ) {
 	// Prevent infinite loops!
-	if ( $query instanceof WP_ES_Query ) {
+	if ( $query instanceof ES_WP_Query ) {
 		return;	
 	}
 	

--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -21,6 +21,11 @@ add_filter( 'query_vars', 'es_wp_query_arg' );
  * @return void
  */
 function es_wp_query_shoehorn( &$query ) {
+	// Prevent infinite loops!
+	if ( $query instanceof WP_ES_Query ) {
+		return;	
+	}
+	
 	if ( true == $query->get( 'es' ) ) {
 		$conditionals = array(
 			'is_single'            => false,


### PR DESCRIPTION
We shouldn't try to shoehorn a query being triggered by ES_WP_Query itself.

If I have a very broad `pre_get_posts` hook:

```
add_action( 'pre_get_posts', function( $query ) {
    $query->set( 'es', true );
} );
```

This can end up creating an infinite loop.

1) WP_Query triggers `pre_get_posts` and our callback adds the `es` property
2) `es_wp_query_shoehorn` runs next which picks up the `es` arg and creates an `ES_WP_Query` object.
3) `ES_WP_Query` also triggers `pre_get_posts` which fires our callback and adds the `es` property.
4) `es_wp_query_shoehorn` also runs on this hook and because the `es` arg was set, it creates an `ES_WP_Query` object.
5) And repeat 🔁 

➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ 
➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ 
➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ 
➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ 
➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ 
➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ ➿ 