### PR TITLE
Update wpcom-vip Adapter to honor 'post__in' orderby clause

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
+							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+								$sort_post__in = implode( ',', $q['post__in'] );
+							}
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,7 +44,13 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
+							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
+							$sort_post__in = $post__in;
+							$q = $this->query_vars;
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;
 					}


### PR DESCRIPTION
Currently the ES_WP_Query implementation does not honor the 'post__in' orderby clause of WP_Query. To resolve this discrepancy we can tie into the `$wpdb->get_results` query and supply the original 'post__in' query vars.