### PR TITLE
Only add a comment if the query exists

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -180,7 +180,7 @@ class ES_WP_Query_Shoehorn {
 			if ( ! $this->post_count ) {
 				global $wpdb;
 				return "SELECT * FROM {$wpdb->posts} WHERE 1=0 /* ES_WP_Query Shoehorn */";
-			} else {
+			} elseif ( ! empty( $sql ) ) {
 				return $sql . ' /* ES_WP_Query Shoehorn */';
 			}
 		}


### PR DESCRIPTION
On WordPress.com HyperDB analyzes the query to figure out which database server to connect to. If it can't find a table but the query exists it will throw a PHP warning. This change only adds a comment to the sql query if the query exists.