### PR TITLE
More compatibility with WP_Query, when sorting using meta-query keys

### DIFF
--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -1244,13 +1244,15 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 		// Meta values get special treatment
 		$meta_keys = array();
 		$meta_clauses = $this->meta_query->queries;
+		$meta_clauses_types = $this->meta_query->queries_types_all;
+
 		if ( ! empty( $meta_clauses ) ) {
 			if ( 'meta_value' == $orderby ) {
 				return $this->parse_orderby_for_meta( reset( $meta_clauses ) );
 			} elseif ( 'meta_value_num' == $orderby ) {
 				return $this->parse_orderby_for_meta( reset( $meta_clauses ), 'double' );
-			} elseif ( array_key_exists( $orderby, $meta_clauses ) ) {
-				return $this->parse_orderby_for_meta( $meta_clauses[ $orderby ] );
+			} elseif ( array_key_exists( $orderby, $meta_clauses_types ) ) {
+				return $this->parse_orderby_for_meta( $meta_clauses_types[ $orderby ] );
 			}
 		}
 

--- a/tests/query/metaQuery.php
+++ b/tests/query/metaQuery.php
@@ -1739,6 +1739,45 @@ class Tests_Query_MetaQuery extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket XXXX
+	 */
+	public function test_orderby_meta_more_than_one_clause_array_defined() {
+		$posts = $this->factory->post->create_many( 3 );
+
+		add_post_meta( $posts[0], 'foo', 'jjj' );
+		add_post_meta( $posts[1], 'foo', 'zzz' );
+		add_post_meta( $posts[2], 'foo', 'jjj' );
+		add_post_meta( $posts[0], 'bar', 'aaa' );
+		add_post_meta( $posts[1], 'bar', 'ccc' );
+		add_post_meta( $posts[2], 'bar', 'bbb' );
+		es_wp_query_index_test_data();
+
+		$r = array(
+			'fields' => 'ids',
+			'meta_query' => array(
+			),
+			'orderby' => array(
+				'foo_key' => 'asc',
+				'bar_key' => 'desc',
+			),
+		 );
+
+		$r['meta_query'][]['foo_key'] = array(
+			'key' => 'foo',
+			'compare' => 'EXISTS',
+		);
+
+		$r['meta_query'][]['bar_key'] = array(
+			'key' => 'bar',
+			'compare' => 'EXISTS',
+		);
+
+		$q = new ES_WP_Query( $r );
+
+		$this->assertEquals( array( $posts[2], $posts[0], $posts[1] ), $q->posts );
+	}
+
+	/**
 	 * @ticket 31045
 	 */
 	public function test_duplicate_clause_keys_should_be_made_unique() {


### PR DESCRIPTION
WP_Query supports specifying meta-queries such as the following, where $args are the
arguments to WP_Query() :

    $args['meta_query'][]['pv_date'] = array(
        'key' => 'pv_date',
        'type' => 'NUMERIC',
        'compare' => 'EXISTS',
    );

    $args['meta_query'][]['pv_count'] = array(
        'key' => 'pv_count',
        'type' => 'NUMERIC',
        'compare' => 'EXISTS',
    );

Currently these are processed correctly by es-wp-query, but associated
ordering clauses are not, for instance:

    $args["orderby"] => Array(
        "pv_date" => "desc",
    	"pv_count" => "desc"
    );

This is because sorting-arguments are filtered, so unrecognised ones are left
out. However, that process does not include meta-queries that are specified as shown
above, with the result that the sorting arguments are ignored.

The patch will ensure processing of these meta-queries, and allow sorting to
take place.