### PR TITLE
Update the  logic to use posts_per_page of query vs option

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -104,8 +104,11 @@ class ES_WP_Query_Shoehorn {
 
 	private $original_query_args;
 
+	private $posts_per_page;
+
 	public function __construct( &$query, &$es_query, $query_args ) {
 		$this->hash = spl_object_hash( $query );
+		$this->posts_per_page = $es_query->get( 'posts_per_page' );
 
 		if ( $query->get( 'no_found_rows' ) || -1 == $query->get( 'posts_per_page' ) || true == $query->get( 'nopaging' ) ) {
 			$this->do_found_posts = false;
@@ -221,7 +224,7 @@ class ES_WP_Query_Shoehorn {
 
 		// Restore some necessary defaults if we zapped 'em
 		if ( empty( $q['posts_per_page'] ) ) {
-			$q['posts_per_page'] = get_option( 'posts_per_page' );
+			$q['posts_per_page'] = $this->posts_per_page;
 		}
 	}
 }


### PR DESCRIPTION
Resolve issue #18 where posts_per_page is being set to the default option value vs the value calculated by theme/plugin filters.