### PR TITLE
Replace 'any' with query vars for type and status

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -66,8 +66,8 @@ function es_wp_query_shoehorn( &$query ) {
 		$es_query = new ES_WP_Query( $es_query_vars );
 
 		$query->parse_query( array(
-			'post_type'        => 'any',
-			'post_status'      => 'any',
+			'post_type'        => $query->get( 'post_type' ),
+			'post_status'      => $query->get( 'post_status' ),
 			'post__in'         => $es_query->posts,
 			'posts_per_page'   => $es_query->post_count,
 			'fields'           => $query->get( 'fields' ),


### PR DESCRIPTION
This fix means that the intention of the original query isn't overridden by `es-wp-query`, and means that all forms of post status are viewable if intended.

Fixes #61 