### PR TITLE
Don't add ES_WP_Query Shoehorn if $sql is empty

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
+							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+								$sort_post__in = implode( ',', $q['post__in'] );
+							}
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,13 +44,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
-							$sort_post__in = $post__in;
-							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,7 +44,13 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
+							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
+							$sort_post__in = $post__in;
+							$q = $this->query_vars;
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-								$sort_post__in = implode( ',', $q['post__in'] );
-							}
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -190,7 +190,7 @@ class ES_WP_Query_Shoehorn {
 			if ( ! $this->post_count ) {
 				global $wpdb;
 				return "SELECT * FROM {$wpdb->posts} WHERE 1=0 /* ES_WP_Query Shoehorn */";
-			} else {
+			} else if ( ! empty( $sql ) ) {
 				return $sql . ' /* ES_WP_Query Shoehorn */';
 			}
 		}


### PR DESCRIPTION
In some scenarios we have seen that `$sql` is null when `filter__posts_request` is called due to customizations in various themes. This update ensures that $sql is set before appending the Shoehorn comment.