### PR TITLE
ES_WP_Query inappropriately setting `is_search` flag

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
+							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+								$sort_post__in = implode( ',', $q['post__in'] );
+							}
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,13 +44,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
-							$sort_post__in = $post__in;
-							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,7 +44,13 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
+							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
+							$sort_post__in = $post__in;
+							$q = $this->query_vars;
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-								$sort_post__in = implode( ',', $q['post__in'] );
-							}
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -65,6 +65,16 @@ function es_wp_query_shoehorn( &$query ) {
 		// Run this query through ES.
 		$es_query_vars = $query->query_vars;
 		$es_query_vars['fields'] = 'ids';
+
+		/*
+		 * WP_Query, when doing initial query parsing, sets `is_search` to `true` when
+		 * `s` attribute exists, not only when it's non-empty. The `s` attribute also
+		 * gets backfilled, so we need to reset it, when appropriate.
+		*/
+		if ( true === empty( $es_query_vars['s'] ) && false === $query->is_search ) {
+			unset( $es_query_vars['s'] );
+		}
+
 		$es_query = new ES_WP_Query( $es_query_vars );
 
 		// Make the post query use the post IDs from the ES results instead.


### PR DESCRIPTION
WP_Query, when doing initial query parsing, sets `is_search` to `true` when `s` attribute exists, not only when it's non-empty. The `s` attribute also gets backfilled, so we need to reset it, when appropriate.