### PR TITLE
Allow adapters to normalize term value (like `strtolower` if mapping to `raw_lc`).

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
+							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+								$sort_post__in = implode( ',', $q['post__in'] );
+							}
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,13 +44,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
-							$sort_post__in = $post__in;
-							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,7 +44,13 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
+							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
+							$sort_post__in = $post__in;
+							$q = $this->query_vars;
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-								$sort_post__in = implode( ',', $q['post__in'] );
-							}
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -145,11 +145,25 @@ function vip_es_field_map( $es_map ) {
 add_filter( 'es_field_map', 'vip_es_field_map' );
 
 function vip_es_meta_value_tolower( $meta_value, $meta_key, $meta_compare, $meta_type ) {
-	if ( ! empty( $meta_value ) && is_string( $meta_value ) ) {
-		$meta_value = strtolower( $meta_value );
-	} else if ( ! empty( $meta_value ) && is_array( $meta_value ) ) {
-		$meta_value = array_map( 'strtolower', $meta_value );
+	if ( ! is_string( $meta_value ) || empty( $meta_value ) ) {
+		return $meta_value;
 	}
-	return $meta_value;
+	return strtolower( $meta_value );
 }
 add_filter( 'es_meta_query_meta_value', 'vip_es_meta_value_tolower', 10, 4 );
+
+/**
+ * Normalise term name to lowercase as we are mapping that against raw_lc field.
+ *
+ * @param $term string|mixed Term's name which should be normalised to lowercase.
+ * @param $taxonomy string Taxonomy of the term.
+ * @return mixed If $term is a string, lowercased string is returned. Otherwise original value is return unchanged.
+ */
+function vip_es_term_name_slug_tolower( $term, $taxonomy ) {
+	if ( ! is_string( $term ) || empty( $term ) ) {
+		return $term;
+	}
+	return strtolower( $term );
+}
+add_filter( 'es_tax_query_term_name', 'vip_es_term_name_slug_tolower', 10, 2 );
+

--- a/class-es-wp-tax-query.php
+++ b/class-es-wp-tax-query.php
@@ -174,6 +174,17 @@ class ES_WP_Tax_Query extends WP_Tax_Query {
 					 * context is 'db'.
 					 */
 					$term = sanitize_term_field( $clause['field'], $term, 0, $clause['taxonomy'], 'db' );
+
+					/**
+					 * Allow adapters to normalize term value (like `strtolower` if mapping to `raw_lc`).
+					 *
+					 * The dynamic portion of the filter name, `$clause['field']`, refers to the term field.
+					 *
+					 * @param mixed $term Term's slug or name sanitised using `sanitize_term_field` function for db context.
+					 * @param string $taxonomy Term's taxonomy slug.
+					 */
+					$term = apply_filters( "es_tax_query_term_{$clause['field']}", $term, $clause['taxonomy'] );
+
 				}
 				$current_filter = call_user_func( $terms_method, $this->es_query->tax_map( $clause['taxonomy'], 'term_' . $clause['field'] ), $clause['terms'] );
 				break;


### PR DESCRIPTION
Create a `es_tax_query_term_{$clause['field']}` term filter allowing for normalization of terms for field mappings.

Also apply filter to wpcom adapter.