### PR TITLE
WPCOM Adapter : Disable Advanced Post Cache

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
+							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+								$sort_post__in = implode( ',', $q['post__in'] );
+							}
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,13 +44,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
-							$sort_post__in = $post__in;
-							$q = $this->query_vars;
-                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-                                $sort_post__in = implode( ',', $q['post__in'] );
-                            }
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -44,7 +44,13 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 						if ( ! empty( $post_ids ) ) {
 							global $wpdb;
 							$post__in = implode( ',', $post_ids );
-							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $post__in )" );
+							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
+							$sort_post__in = $post__in;
+							$q = $this->query_vars;
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
+							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;
 					}

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -153,3 +153,82 @@ function vip_es_meta_value_tolower( $meta_value, $meta_key, $meta_compare, $meta
 	return $meta_value;
 }
 add_filter( 'es_meta_query_meta_value', 'vip_es_meta_value_tolower', 10, 4 );
+
+/*
+ * Advanced Post Cache and es-wp-query do not work well together. In
+ * particular, the WP_Query->found_posts attribute gets corrupted when using
+ * both of these plugins, so here we disable Advanced Post Cache completely
+ * when queries are being made using Elasticsearch.
+ *
+ * On the other hand, if a non-Elasticsearch query is run, and we disabled
+ * Advanced Post Cache earlier, we enable it again, to make use of its caching
+ * features.
+ *
+ * Note that this applies only to calles done via WP_Query(), and not
+ * ES_WP_Query()
+ */
+function es_disable_advanced_post_cache( &$query ) {
+	global $advanced_post_cache_object;
+
+	static $disabled_apc = false;
+
+
+	/*
+	 * These two might be passsed to us; we only
+	 * handle WP_Query, so ignore these.
+	 */
+
+	if (
+		( $query instanceof ES_WP_Query_Wrapper ) ||
+		( $query instanceof ES_WP_Query )
+	) {
+		return;
+	}
+
+	if ( $query->get( 'es' ) ) {
+		if ( true === $disabled_apc ) {
+			/* Already disabled, don't try again */
+			return;
+		}
+
+		/*
+		 * An Elasticsearch-enabled query is being run. Disable
+		 * Advanced Post Cache entirely.
+		 *
+		 * Note that there is one action-hook that is not deactivated:
+		 * The switch_blog action is not deactivated, because it might be
+		 * called in-between Elasticsearch-enabled query, and a non-Elasticsearch
+		 * query, and because it does not have an effect on WP_Query()-results directly.
+		 */
+
+		remove_filter( 'posts_request', array( $advanced_post_cache_object, 'posts_request' ) );
+		remove_filter(  'posts_results', array( $advanced_post_cache_object, 'posts_results' ) );
+
+		remove_filter( 'post_limits_request', array( $advanced_post_cache_object, 'post_limits_request' ), 999 );
+
+		remove_filter( 'found_posts_query', array( $advanced_post_cache_object, 'found_posts_query' ) );
+		remove_filter( 'found_posts', array( $advanced_post_cache_object, 'found_posts' ) );
+
+		$disabled_apc = true;
+	} else {
+
+		/* A non-ES query */
+
+		if ( true === $disabled_apc ) {
+			/*
+			 * Earlier, we disabled Advanced Post Cache
+			 * entirely, but now a non-Elasticsearch query is
+			 * being run, and in such cases it might be useful
+			 * to have the Cache enabled. Here we enable
+			 * it again.
+			 */
+
+			$advanced_post_cache_object->__construct();
+
+			$disabled_apc = false;
+		}
+	}
+}
+
+add_action( 'pre_get_posts', 'es_disable_advanced_post_cache', -100 );
+

--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -47,9 +47,9 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 							// Explicitly set the sort post__in property to allow for final posts to honor orderby = 'post__in'.
 							$sort_post__in = $post__in;
 							$q = $this->query_vars;
-							if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
-								$sort_post__in = implode( ',', $q['post__in'] );
-							}
+                            if( 'post__in' == $q['orderby'] && ! empty( $q['post__in'] ) ) {
+                                $sort_post__in = implode( ',', $q['post__in'] );
+                            }
 							$this->posts = $wpdb->get_results( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN ($post__in) ORDER BY FIELD( {$wpdb->posts}.ID, $sort_post__in )" );
 						}
 						return;


### PR DESCRIPTION
Advanced Post Cache and es-wp-query do not work well together. In particular, the WP_Query->found_posts attribute gets corrupted when using both of these plugins, so here we disable Advanced Post Cache completely when queries are being made using Elasticsearch.