### PR TITLE
Image Search Enhancements

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -128,7 +128,7 @@ function vip_es_field_map( $es_map ) {
 		'post_modified_gmt.second'      => 'modified_gmt_token.second',
 		'post_parent'                   => 'parent_post_id',
 		'menu_order'                    => 'menu_order',     // this isn't indexed on vip
-		'post_mime_type'                => 'post_mime_type', // this isn't indexed on vip
+		'post_mime_type'                => 'post_mime_type.raw', // this isn't indexed on vip
 		'comment_count'                 => 'comment_count',  // this isn't indexed on vip
 		'post_meta'                     => 'meta.%s.value.raw_lc',
 		'post_meta.analyzed'            => 'meta.%s.value',

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -808,7 +808,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 			$r_status = array();
 			$p_status = array();
 			$e_status = array();
-			if ( in_array('any', $q_status) ) {
+			if ( in_array('any', $q_status) || in_array( 'inherit', $q_status ) ) {
 				$e_status = get_post_stati( array( 'exclude_from_search' => true ) );
 				$e_status = array_values( $e_status );
 			} else {


### PR DESCRIPTION
ES_WP_Query currently does a prefix search on the post_mime_type field. To perform this type of query the raw field needs to be utilized.

Currently no support exists for the "inherit" post_status search. This is a common post_status used when doing image searches. This patch sets the post_type equal to all searchable post_status (same logic as used for the post_status any).