### PR TITLE
Filter `$es_args` in Jetpack Search adapter

### DIFF
--- a/adapters/jetpack-search.php
+++ b/adapters/jetpack-search.php
@@ -23,6 +23,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 		if ( class_exists( 'Jetpack_Search' ) ) {
 			$jetpack_search = Jetpack_Search::instance();
 			if ( method_exists( $jetpack_search, 'search' ) ) {
+				$es_args = apply_filters( 'jetpack_search_es_query_args', $es_args, $this );
 				return $jetpack_search->search( $es_args );
 			}
 		}


### PR DESCRIPTION
In Jetpack Search, it is possible to change the ES query directly using the `jetpack_search_es_query_args` filter. However, since `es_query()` method is calling the `search()` method of `Jetpack_Search`, this filter never runs, therefore any changes to the ES query will not work. By filtering the `$es_args` with `jetpack_search_es_query_args`, we can be sure that any changes to the query will be honoured.

As a side note, `jetpack_search_es_query_args` filter expects the first argument to be a ES query, and the second argument to be a WP_Query object, so it's possible to reuse this filter directly here without any issues. 

Related: https://developer.jetpack.com/hooks/jetpack_search_es_query_args/