### PR TITLE
Feature/is main query

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -24,7 +24,7 @@ add_filter( 'query_vars', 'es_wp_query_arg' );
  * If a WP_Query object has `'es' => true`, use Elasticsearch to run the meat of the query.
  * This is fires on the "pre_get_posts" action.
  *
- * @param  object $query WP_Query object.
+ * @param  WP_Query $query - Current full WP_Query object.
  * @return void
  */
 function es_wp_query_shoehorn( &$query ) {
@@ -78,7 +78,9 @@ function es_wp_query_shoehorn( &$query ) {
 		 */
 		$es_query_args           = $query->query;
 		$es_query_args['fields'] = 'ids';
+		$es_query_args['is_main_query'] = $query->is_main_query();
 		$es_query                = new ES_WP_Query( $es_query_args );
+
 
 		// Make the post query use the post IDs from the ES results instead.
 		$query->parse_query(
@@ -90,7 +92,7 @@ function es_wp_query_shoehorn( &$query ) {
 				'fields'         => $query->get( 'fields' ),
 				'orderby'        => 'post__in',
 				'order'          => 'ASC',
-			) 
+			)
 		);
 
 		// Reinsert all the conditionals from the original query.

--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -81,7 +81,6 @@ function es_wp_query_shoehorn( &$query ) {
 		$es_query_args['is_main_query'] = $query->is_main_query();
 		$es_query                = new ES_WP_Query( $es_query_args );
 
-
 		// Make the post query use the post IDs from the ES results instead.
 		$query->parse_query(
 			array(

--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -78,7 +78,7 @@ function es_wp_query_shoehorn( &$query ) {
 		 */
 		$es_query_args           = $query->query;
 		$es_query_args['fields'] = 'ids';
-		$es_query_args['is_main_query'] = $query->is_main_query();
+		$es_query_args['es_is_main_query'] = $query->is_main_query();
 		$es_query                = new ES_WP_Query( $es_query_args );
 
 		// Make the post query use the post IDs from the ES results instead.

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -54,7 +54,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 	 * @return bool
 	 */
 	public function is_main_query() {
-		return $this->get( 'is_main_query', false );
+		return $this->get( 'es_is_main_query', false );
 	}
 
 	/**

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -34,6 +34,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 	 */
 	public $es_response;
 
+
 	/**
 	 * Construct for querying Elasticsearch. Must be implemented in child classes.
 	 *
@@ -42,6 +43,19 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 	 * @return array The response from the Elasticsearch server.
 	 */
 	abstract protected function query_es( $es_args );
+
+	/**
+	 * Override default WP_Query->is_main_query() to support
+	 * this conditional when the main query has been overridden
+	 * by this class.
+	 *
+	 * @fixes #38
+	 *
+	 * @return bool
+	 */
+	public function is_main_query() {
+		return $this->get( 'is_main_query', false );
+	}
 
 	/**
 	 * Maps a field to its Elasticsearch context.
@@ -253,7 +267,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 				'tag_slug'           => 'terms.%s.slug',
 				'tag_name'           => 'terms.%s.name',
 				'tag_tt_id'          => 'terms.%s.term_taxonomy_id',
-			) 
+			)
 		);
 
 		$this->parse_query();
@@ -424,7 +438,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 						'after'     => $date,
 						'before'    => $date,
 						'inclusive' => true,
-					) 
+					)
 				);
 				$date_filter = $date_query->get_dsl( $this );
 				if ( ! empty( $date_filter ) ) {
@@ -995,8 +1009,8 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 						array(
 							'protected'              => true,
 							'show_in_admin_all_list' => true,
-						) 
-					) 
+						)
+					)
 				);
 			}
 
@@ -1153,7 +1167,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 				'fields' => $fields,
 				'size'   => $size,
 				'from'   => $from,
-			) 
+			)
 		);
 
 		// Filter again for the benefit of caching plugins. Regular plugins should use the hooks above.
@@ -1312,7 +1326,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 						'post_type'   => $post_type,
 						'post_status' => 'publish',
 						'nopaging'    => true, // phpcs:ignore WordPress.VIP.PostsPerPage.posts_per_page_nopaging
-					) 
+					)
 				);
 
 				foreach ( $stickies as $sticky_post ) {
@@ -1635,7 +1649,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 					'query'  => $query,
 					'fields' => (array) $fields,
 				),
-				$args 
+				$args
 			),
 		);
 	}


### PR DESCRIPTION
## Support using `$query->is_main_query()` when `ES_WP_Query` is replacing `WP_Query`

Automatically passed a `query_var` which is later used within an override method of `is_main_query` during `pre_get_posts` actions.

Fixes #38 
