### PR TITLE
Introduce `es_query_use_es` filter to enable/disable ES

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -33,7 +33,8 @@ function es_wp_query_shoehorn( &$query ) {
 		return;
 	}
 
-	if ( ! empty( $query->get( 'es' ) ) ) {
+	if ( apply_filters( 'es_query_use_es', ! empty( $query->get( 'es' ) ), $query ) ) {
+
 		// Backup the conditionals to restore later.
 		$conditionals = array(
 			'is_single'            => false,


### PR DESCRIPTION
## Introduce `es_query_use_es` Filter

Allows enabling/disabling site or section wide es based on outside
callbacks.

Useful for installs with unusual ES limitations which need to be disabled if particular query_vars are passed.