### PR TITLE
Prevent sitemap.xml from 404ing

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -294,6 +294,11 @@ class ES_WP_Query_Shoehorn {
 			$q['posts_per_page'] = $this->posts_per_page;
 		}
 
+		if ( $query->is_page() && ! empty( $q['pagename'] ) ) {
+			$q['pagename'] = sanitize_title_for_query( wp_basename( $q['pagename'] ) );
+			$q['name']     = $q['pagename'];
+		}
+
 		// Restore the author ID which is normally added during get_posts() in WP_Query.
 		// Required for handle_404() in WP class to not mark empty author archives as 404s.
 		if ( $query->is_author() && ! empty( $q['author_name'] ) ) {

--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -294,9 +294,9 @@ class ES_WP_Query_Shoehorn {
 			$q['posts_per_page'] = $this->posts_per_page;
 		}
 
-		if ( $query->is_page() && ! empty( $q['pagename'] ) ) {
+		// Allow sitemap.xml redirect to wp-sitemap.xml page.
+		if ( 'sitemap.xml' === $q['pagename'] ) {
 			$q['pagename'] = sanitize_title_for_query( wp_basename( $q['pagename'] ) );
-			$q['name']     = $q['pagename'];
 		}
 
 		// Restore the author ID which is normally added during get_posts() in WP_Query.


### PR DESCRIPTION
Reproduction
===
- Ensure WP sitemaps is enabled
- Offload pages to ES:
```
function page_es_offload( $query ) {

	if ( $query->is_main_query() && $query->is_page() ) { // Conditions to offload to ES.
    	$query->set( 'es', true );
	}
}
add_action( 'pre_get_posts', 'page_es_offload' );
```
- Visit /sitemap.xml

Expectation
===
When Accessing `sitemap.xml`, it should redirect to `wp-sitemap.xml`: https://github.com/WordPress/WordPress/blob/5.8.1/wp-includes/sitemaps/class-wp-sitemaps.php#L237

Actual
===
Accessing `sitemap.xml` leads to a 404 because it doesn't redirect due to lack of `pagename` sanitization, as the value ends up being `sitemap.xml` rather than `sitemap-xml`: https://github.com/WordPress/WordPress/blob/5.8.1/wp-includes/class-wp-query.php#L2062

Reported: https://github.com/Automattic/vip-go-mu-plugins/issues/2430