### PR TITLE
Handle more complicated mime queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ wpcom-helper.php
 .DS_Store
 /report/
 .idea
+.vscode

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -799,10 +799,10 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 				$filter[] = $es_mime['filters'];
 			}
 			if ( ! empty( $es_mime['query'] ) ) {
-				if ( empty( $query['should'] ) ) {
-					$query['should'] = $es_mime['query'];
+				if ( empty( $query['must'] ) ) {
+					$query['must'] = $es_mime['query'];
 				} else {
-					$query['should'] = array_merge( $query['should'], $es_mime['query'] );
+					$query['must'] = array_merge( $query['must'], $es_mime['query'] );
 				}
 			}
 		}
@@ -1216,7 +1216,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 			$size                  = apply_filters( 'es_query_max_results', 1000 );
 			$this->es_args['size'] = $size;
 		}
-		
+
 		// ES > 7.0 doesn't return the actual total hits by default (capped at 10k), but we need accurate counts
 		$this->es_args[ 'track_total_hits' ] = true;
 

--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -796,7 +796,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 		if ( isset( $q['post_mime_type'] ) && '' !== $q['post_mime_type'] ) {
 			$es_mime = $this->post_mime_type_query( $q['post_mime_type'], $wpdb->posts );
 			if ( ! empty( $es_mime['filters'] ) ) {
-				$filter[] = $es_mime['filters'];
+				$filter = array_values( array_merge( $filter, $es_mime['filters'] ) );
 			}
 			if ( ! empty( $es_mime['query'] ) ) {
 				if ( empty( $query['must'] ) ) {
@@ -1557,14 +1557,19 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 
 			if ( false !== strpos( $mime_pattern, '*' ) ) {
 				$mime_pattern = preg_replace( '/\*+/', '', $mime_pattern );
-				$query[]      = array( 'prefix' => array( $this->es_map( 'post_mime_type' ) => $mime_pattern ) );
+				$filters[]    = array( 'prefix' => array( $this->es_map( 'post_mime_type' ) => $mime_pattern ) );
 			} else {
 				$strict_mime_types[] = $mime_pattern;
 			}
 		}
 
 		if ( ! empty( $strict_mime_types ) ) {
-			$filters = $this->dsl_terms( $this->es_map( 'post_mime_type' ), $strict_mime_types );
+			$filters = array_merge(
+				$filters,
+				[
+					$this->dsl_terms( $this->es_map( 'post_mime_type' ), $strict_mime_types ),
+				],
+			);
 		}
 
 		return compact( 'filters', 'query' );


### PR DESCRIPTION
Add support for more complicated `post_mime_type` queries. A query can have a valid mime type (such as `application/pdf`), a prefixed type (such as `image`), OR a combination of both. The latter was failing and only returned the incorrect attachments. 

For example, this was the search results for a query of `image`, `video/mp4`, and `video/oog` (note the missing images):

<img width="1154" alt="Screen Shot 2022-09-26 at 5 44 09 PM" src="https://user-images.githubusercontent.com/346399/193125007-6dcc20e3-c567-4f62-aec2-188dac8894a3.png">

Expected result:

<img width="1378" alt="Screen Shot 2022-09-29 at 3 31 35 PM" src="https://user-images.githubusercontent.com/346399/193125114-e6f3203c-73b9-45fd-9a85-12d923284d7a.png">

The more complicated combination of explicit mime type and prefix mime types was converted to a bool query where as the other types of queries were converted to a filter.