### PR TITLE
Add minimum_should_match for mime query

### DIFF
--- a/class-es-wp-query-wrapper.php
+++ b/class-es-wp-query-wrapper.php
@@ -799,6 +799,7 @@ abstract class ES_WP_Query_Wrapper extends WP_Query {
 				$filter = array_values( array_merge( $filter, $es_mime['filters'] ) );
 			}
 			if ( ! empty( $es_mime['query'] ) ) {
+				$query['minimum_should_match'] = 1;
 				if ( empty( $query['should'] ) ) {
 					$query['should'] = $es_mime['query'];
 				} else {


### PR DESCRIPTION
This addresses a [breaking change in ES 7.x](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#_the_filter_context_has_been_removed) that's gone unnoticed.
