### PR TITLE
Introduce the `es_wp_query_shoehorn` action hook

### DIFF
--- a/class-es-wp-query-shoehorn.php
+++ b/class-es-wp-query-shoehorn.php
@@ -19,13 +19,11 @@ function es_wp_query_arg( $vars ) {
 }
 add_filter( 'query_vars', 'es_wp_query_arg' );
 
-
 /**
  * If a WP_Query object has `'es' => true`, use Elasticsearch to run the meat of the query.
  * This is fires on the "pre_get_posts" action.
  *
- * @param  WP_Query $query - Current full WP_Query object.
- * @return void
+ * @param WP_Query $query Current full WP_Query object.
  */
 function es_wp_query_shoehorn( &$query ) {
 	// Prevent infinite loops!
@@ -98,6 +96,15 @@ function es_wp_query_shoehorn( &$query ) {
 		foreach ( $conditionals as $key => $value ) {
 			$query->$key = $value;
 		}
+
+		/**
+		 * Fires before the ES_WP_Query_Shoehorn class is instantiated.
+		 *
+		 * @param WP_Query    $query Current full WP_Query object.
+		 * @param ES_WP_Query $es_query Current full ES_WP_Query object.
+		 * @param array       $query_args Query arguments.
+		 */
+		do_action( 'es_wp_query_shoehorn', $query, $es_query, $query_args );
 
 		new ES_WP_Query_Shoehorn( $query, $es_query, $query_args );
 	}


### PR DESCRIPTION
Introduce the `es_wp_query_shoehorn` action hook that fires before the `ES_WP_Query_Shoehorn` class is instantiated.

This one way that I was able to solve this problem: https://github.com/alleyinteractive/searchpress/issues/186

Here, one have access to the es query and the main query and can add information back to the main query if necessary.