### PR TITLE
fix: jetpack search initializer blog id

### DIFF
--- a/adapters/jetpack-search.php
+++ b/adapters/jetpack-search.php
@@ -23,7 +23,7 @@ class ES_WP_Query extends ES_WP_Query_Wrapper {
 		$jetpack_search = null;
 		
 		if ( class_exists( 'Automattic\Jetpack\Search\Classic_Search' ) ) {
-			$jetpack_search = Automattic\Jetpack\Search\Classic_Search::initialize( get_current_blog_id() );
+			$jetpack_search = Automattic\Jetpack\Search\Classic_Search::initialize( \Automattic\Jetpack\Search\Helper::get_wpcom_site_id() );
 		} else if ( class_exists( 'Jetpack_Search' ) ) {
 			$jetpack_search = Jetpack_Search::instance();
 		


### PR DESCRIPTION
The expected value for the classic search initializer is the site's wpcom ID, not its multisite blog ID.

The issue only appears when Jetpack's Instant Search module is enabled, which prevents the Classic_Search singleton from being first initialized. When initializing through the ES_WP_Query it's misconfigured and fails to perform requests.